### PR TITLE
Ensure UTF-8 console output

### DIFF
--- a/ConformU/ConformLogger.cs
+++ b/ConformU/ConformLogger.cs
@@ -7,6 +7,11 @@ namespace ConformU
 {
     public class ConformLogger : TraceLogger, ITraceLogger, IDisposable
     {
+        static ConformLogger()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+        }
+
         private bool debug;
         public ConformLogger(string logFileName, string logFilePath, string loggerName, bool enabled) : base(logFileName, logFilePath, loggerName, enabled)
         {


### PR DESCRIPTION
Some logs (at least one where I encountered this is Dome output [here](https://github.com/ASCOMInitiative/ConformU/blob/6070aaea2b94f3f903afe7913045d0b5483052bc/ConformU/Conform/DomeTester.cs#L631)) output Unicode characters.

Those work fine in modern terminals, which assume UTF-8 by default, but for legacy reasons will break in other environments, e.g. when piping the process to a file or launching as a child process (the last one is how I found it, I'm running ConformU as a child process in a test runner). In that case the Unicode character would be corrupted and printed as "within tolerance �1 degrees".

In this PR I'm setting the application to explicitly switch to the UTF-8 encoding regardless of the defaults used by the parent process. This fixes the issue and makes the output "within tolerance ±1 degrees" in all environments as expected.
