### PR TITLE
Use same logging format for both test modes

### DIFF
--- a/ConformU/AlpacaProtocolTestManager.cs
+++ b/ConformU/AlpacaProtocolTestManager.cs
@@ -50,15 +50,6 @@ namespace ConformU
         private readonly List<string> informationMessages;
         private readonly List<string> errorMessages;
 
-        internal enum TestOutcome
-        {
-            OK,
-            Info,
-            Issue,
-            Error,
-            Debug
-        }
-
         private enum AdditionalParameterCheck
         {
             None,
@@ -421,7 +412,7 @@ namespace ConformU
             }
             catch (Exception ex)
             {
-                LogMessage("TestAlpacaProtocol", TestOutcome.Error, $"Exception: {ex}");
+                LogMessage("TestAlpacaProtocol", MessageLevel.Error, $"Exception: {ex}");
             }
 
             return returnCode;
@@ -3099,45 +3090,15 @@ namespace ConformU
         ///<param name="method">Calling method name</param>
         ///    <param name = "message" > Message to log</param>
         ///    <param name = "padding" > Number of characters to which the message should be right padded</param>
-        private void LogMessage(string method, TestOutcome outcome, string message, string contextMessage = null)
+        private void LogMessage(string method, MessageLevel outcome, string message, string contextMessage = null)
         {
-            string methodString, outcomeString, methodStringNoOutcome;
-
-            switch (outcome)
-            {
-                case TestOutcome.OK:
-                    outcomeString = "OK";
-                    break;
-
-                case TestOutcome.Info:
-                    outcomeString = "INFO";
-                    break;
-
-                case TestOutcome.Issue:
-                    outcomeString = "ISSUE";
-                    break;
-
-                case TestOutcome.Error:
-                    outcomeString = "ERROR";
-                    break;
-
-                case TestOutcome.Debug:
-                    outcomeString = "DEBUG";
-                    break;
-
-                default:
-                    throw new Exception($"Unknown test outcome type: {outcome}");
-            }
-            methodString = $"{method,-ExtensionMethods.COLUMN_WIDTH}{outcomeString,-ExtensionMethods.OUTCOME_WIDTH}";
-            methodStringNoOutcome = $"{method,-ExtensionMethods.COLUMN_WIDTH}{"",-ExtensionMethods.OUTCOME_WIDTH}";
-
             // Write to the logger
-            TL?.LogMessage(methodString, message);
+            TL?.LogMessage(method, outcome, message);
 
             // Add the context message if present
             if (contextMessage is not null)
             {
-                TL?.LogMessage(methodStringNoOutcome, $"  Response: {contextMessage}");
+                TL?.LogMessage(method, MessageLevel.Debug, $"  Response: {contextMessage}");
             }
         }
 
@@ -3165,12 +3126,12 @@ namespace ConformU
                 if (settings.AlpacaConfiguration.ProtocolShowSuccessResponses)
                 {
                     // Include JSON responses
-                    LogMessage(method, TestOutcome.OK, message, contextMessage);
+                    LogMessage(method, MessageLevel.OK, message, contextMessage);
                 }
                 else
                 {
                     // Do not include JSON responses
-                    LogMessage(method, TestOutcome.OK, message);
+                    LogMessage(method, MessageLevel.OK, message);
                 }
             }
         }
@@ -3182,7 +3143,7 @@ namespace ConformU
         /// <param name = "message" > Message to log</param>
         private void LogIssue(string method, string message, string contextMessage)
         {
-            LogMessage(method, TestOutcome.Issue, message, contextMessage);
+            LogMessage(method, MessageLevel.Issue, message, contextMessage);
             issueMessages.Add($"{method} ==> {message}\r\n  Response: {contextMessage}\r\n");
         }
 
@@ -3193,7 +3154,7 @@ namespace ConformU
         /// <param name = "message" > Message to log</param>
         private void LogError(string method, string message, string contextMessage)
         {
-            LogMessage(method, TestOutcome.Error, message, contextMessage);
+            LogMessage(method, MessageLevel.Error, message, contextMessage);
             errorMessages.Add($"{method} ==> {message}\r\n  Response: {contextMessage}\r\n");
         }
 
@@ -3207,7 +3168,7 @@ namespace ConformU
             // Only display Information messages if configured to do so
             if ((settings.AlpacaConfiguration.ProtocolMessageLevel == ProtocolMessageLevel.Information) || (settings.AlpacaConfiguration.ProtocolMessageLevel == ProtocolMessageLevel.All))
             {
-                LogMessage(method, TestOutcome.Info, message, contextMessage);
+                LogMessage(method, MessageLevel.Info, message, contextMessage);
                 informationMessages.Add($"{method} ==> {message} {(string.IsNullOrEmpty(contextMessage) ? "" : $"\r\n  Response: {contextMessage}")}\r\n"); //
             }
         }
@@ -3220,7 +3181,7 @@ namespace ConformU
         private void LogDebug(string method, string message)
         {
             if (settings.Debug)
-                LogMessage(method, TestOutcome.Debug, message, null);
+                LogMessage(method, MessageLevel.Debug, message, null);
         }
 
         /// <summary>

--- a/ConformU/ConformLogger.cs
+++ b/ConformU/ConformLogger.cs
@@ -150,27 +150,6 @@ namespace ConformU
             }
         }
 
-        /// <summary>
-        /// Override this method to force consistent use of the LogMessage method.
-        /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="message"></param>
-        public new void Log(ASCOM.Common.Interfaces.LogLevel logLevel, string message)
-        {
-
-            if (logLevel >= base.LoggingLevel)
-            {
-                // Write the message to the console
-                Console.WriteLine($"{logLevel,-TEST_NAME_WIDTH} {message}");
-
-                // Write the message to the log file
-                base.Log(logLevel, $"{string.Empty,-MESSAGE_LEVEL_WIDTH} {message}");
-
-                // Raise the MessaegLogChanged event to Write the message to the screen
-                OnMessageLogChanged($"{logLevel,-TEST_NAME_WIDTH - MESSAGE_LEVEL_WIDTH} {message}");
-            }
-        }
-
         public new void LogMessage(string method, string message)
         {
             // Write the message to the console

--- a/ConformU/ExtensionMethods.cs
+++ b/ConformU/ExtensionMethods.cs
@@ -5,48 +5,7 @@ namespace ConformU
 {
     public static class ExtensionMethods
     {
-        // Constants
-        public const int COLUMN_WIDTH = 30; //
-        public const int OUTCOME_WIDTH = 6;
-
         public static bool IsNumeric(this string text) => !string.IsNullOrWhiteSpace(text) && double.TryParse(text, out _);
-        public static string SpaceDup(this int n)
-        {
-            return new String(' ', n);
-        }
-        public static string ToMultiLine(this string message, int offset, int screenLogColumns)
-        {
-            // Reformat the text across multiple screen lines if the message does not contain HTML code. If it does contain HTML display as-is.
-            int maxLineLength = screenLogColumns - COLUMN_WIDTH - OUTCOME_WIDTH
-                ;
-            string padString = new(' ', COLUMN_WIDTH + OUTCOME_WIDTH + offset);
-            if (screenLogColumns > 0)
-            {
-                // Leave HTML content unchanged
-                if (!message.ToLowerInvariant().Contains("<!doctype html>")) // Not HTML
-                {
-                    string messageTrimmed = message.Trim();
-                    // Convert to multiple lines if message length is over 1 line length
-                    if (messageTrimmed.Length > maxLineLength)
-                    {
-                        // Trim white space from the message before we start
-                        string messageMultiLines = "";
-                        int thisBreakPosition = 0;
-                        int lastBreakPosition = 0;
-                        while (messageTrimmed.Length > lastBreakPosition + maxLineLength)
-                        {
-                            thisBreakPosition = messageTrimmed.LastIndexOf(" ", lastBreakPosition + maxLineLength);
-                            string thisLine = messageTrimmed.Substring(lastBreakPosition, thisBreakPosition - lastBreakPosition).Trim();
-                            messageMultiLines = $"{messageMultiLines}\r\n{padString}{thisLine}";
-                            lastBreakPosition = thisBreakPosition;
-                        }
-
-                        message = $"{messageMultiLines}\r\n{padString}{messageTrimmed.Substring(thisBreakPosition + 1)}"; // Add the remaining characters
-                    }
-                }
-            }
-            return message;
-        }
 
         public static string ToHMS(this double rightAscension)
         {

--- a/ConformU/NetworkLogger.cs
+++ b/ConformU/NetworkLogger.cs
@@ -50,7 +50,6 @@ namespace ConformU
             }
 
             sb.Append(')');
-            Console.WriteLine(sb.ToString());
             logger.LogMessage("NetworkLogger", sb.ToString());
         }
     }

--- a/ConformU/Pages/CheckAlpacaProtocol.razor
+++ b/ConformU/Pages/CheckAlpacaProtocol.razor
@@ -42,15 +42,6 @@
     string statusText;
     ConformU.Settings settings;
 
-    internal enum TestOutcome
-    {
-        OK,
-        Info,
-        Issue,
-        Error,
-        Debug
-    }
-
     #region Blazor lifetime event handlers
 
     protected override void OnInitialized()
@@ -86,10 +77,10 @@
         await Task.Run(() =>
         {
             LogBlankLine();
-            LogLine($"STOP button pressed... stopping tests");
+            logger?.LogMessage("", $"STOP button pressed... stopping tests");
             LogBlankLine();
             applicationCancellationTokenSource.Cancel();
-            LogDebug("StopTest", $"After cancelling - applicationCancellationToken.IsCancellationRequested: {applicationCancellationToken.IsCancellationRequested}");
+            logger?.LogMessage("StopTest", MessageLevel.Debug, $"After cancelling - applicationCancellationToken.IsCancellationRequested: {applicationCancellationToken.IsCancellationRequested}");
         });
     }
 
@@ -219,88 +210,6 @@
     private void ClearLogScreen()
     {
         conformState.ProtocolLog = "";
-    }
-
-    /// <summary>
-    /// Log a formatted message to the screen and log file
-    ///</summary>
-    ///<param name="method">Calling method name</param>
-    ///    <param name = "message" > Message to log</param>
-    ///    <param name = "padding" > Number of characters to which the message should be right padded</param>
-    private async void LogMessage(string method, TestOutcome outcome, string message, string contextMessage = null)
-    {
-        string outcomeString;
-
-        switch (outcome)
-        {
-            case TestOutcome.OK:
-                outcomeString = "OK";
-                break;
-
-            case TestOutcome.Info:
-                outcomeString = "INFO";
-                break;
-
-            case TestOutcome.Issue:
-                outcomeString = "ISSUE";
-                break;
-
-            case TestOutcome.Error:
-                outcomeString = "ERROR";
-                break;
-
-            case TestOutcome.Debug:
-                outcomeString = "DEBUG";
-                break;
-
-            default:
-                throw new Exception($"Unknown test outcome type: {outcome}");
-        }
-        string methodString = $"{method,-ExtensionMethods.COLUMN_WIDTH}{outcomeString,-ExtensionMethods.OUTCOME_WIDTH}";
-
-        // Write to the logger
-        logger?.LogMessage(methodString, message);
-        if (contextMessage is not null) logger?.LogMessage("", contextMessage);
-
-        // Reformat the text across multiple screen lines if the message does not contain HTML code. If it does contain HTML display as-is.
-        conformState.ProtocolLog = $"{conformState.ProtocolLog}\r\n{methodString}{message.Trim(new char[] { ' ', '\r', '\n' })}";
-
-        // Add the context message if present
-        if (contextMessage is not null)
-        {
-            conformState.ProtocolLog = conformState.ProtocolLog + $"\r\n{new string(' ', ExtensionMethods.COLUMN_WIDTH + ExtensionMethods.OUTCOME_WIDTH)}  Response: {contextMessage}".TrimEnd(new char[] { '\r', '\n' });
-        }
-
-        try
-        {
-            await InvokeAsync(() => { StateHasChanged(); });
-            await JS.InvokeVoidAsync("ScrollToBottom", "ProtocolLog");
-        }
-        catch
-        {
-            // ignored
-        }
-    }
-
-    /// <summary>
-    /// Log a debug message
-    /// </summary>
-    /// <param name="method"> Calling method name</param>
-    ///<param name = "message" > Message to log</param>
-    private void LogDebug(string method, string message)
-    {
-        if (settings.Debug)
-            LogMessage(method, TestOutcome.Debug, message, null);
-    }
-
-    /// <summary>
-    /// Log a text line without additional formatting
-    /// </summary>
-    /// <param name="message"></param>
-    private void LogLine(string message)
-    {
-        logger?.LogMessage(message, "");
-        //screenLog = $"{screenLog}\r\n{message}";
     }
 
     /// <summary>


### PR DESCRIPTION
Before this, when writing to the console, `alpacaprotocol` and `conformance` test modes would have different output formats.

This PR changes the protocol one to reuse the ConformLogger's default format, so both are now consistent with each other.

Example before:

```
GET Azimuth                   OK     ClientTransactionID is correctly cased
GET Azimuth                   OK     ServerTransactionID is correctly cased
GET Azimuth                   OK     ErrorNumber is correctly cased
GET Azimuth                   OK     ErrorMessage is correctly cased
GET Azimuth                   OK     JSON Value parameter found OK
GET Azimuth                   OK     Different ClientID casing - The expected ClientTransactionID was returned: 67890
GET Azimuth                   OK     Different ClientID casing - The ServerTransactionID was 1 or greater: 1018
GET Azimuth                   OK     Different ClientID casing - Received HTTP status 200 (OK) as expected.
GET Azimuth                   OK     ClientTransactionID is correctly cased
GET Azimuth                   OK     ServerTransactionID is correctly cased
GET Azimuth                   OK     ErrorNumber is correctly cased
```

After:
```
01:21:29.660 GET Azimuth                         OK       ClientTransactionID is correctly cased
01:21:29.661 GET Azimuth                         OK       ServerTransactionID is correctly cased
01:21:29.661 GET Azimuth                         OK       ErrorNumber is correctly cased
01:21:29.662 GET Azimuth                         OK       ErrorMessage is correctly cased
01:21:29.662 GET Azimuth                         OK       JSON Value parameter found OK
01:21:29.663 GET Azimuth                         OK       Different ClientID casing - The expected ClientTransactionID was returned: 67890
01:21:29.663 GET Azimuth                         OK       Different ClientID casing - The ServerTransactionID was 1 or greater: 1155
01:21:29.664 GET Azimuth                         OK       Different ClientID casing - Received HTTP status 200 (OK) as expected.
01:21:29.665 GET Azimuth                         OK       ClientTransactionID is correctly cased
01:21:29.666 GET Azimuth                         OK       ServerTransactionID is correctly cased
01:21:29.667 GET Azimuth                         OK       ErrorNumber is correctly cased
```